### PR TITLE
Add helper function to handle cases were context-type doesn't contain…

### DIFF
--- a/lib/documentLoader.js
+++ b/lib/documentLoader.js
@@ -130,20 +130,52 @@ async function _pluckDidNode(did, target, didDocument) {
   return Object.assign({'@context': context}, framed['@graph'][0]);
 }
 
+/**
+ * Remote contexts might not return responses with json content types.
+ * In those cases we will need to parse the string or binary stream.
+ *
+ * @param {object} result - The response.
+ *
+ * @returns {Promise<object> - The resulting jsonld document.
+ */
+async function _getDocument(result) {
+  try {
+    // if the response data is a string assume
+    // it is json and parse it
+    if(typeof result.data === 'string') {
+      return JSON.parse(result.data);
+    }
+    // if the resulting data was already parsed by http-client
+    // then return it as is
+    if(result.data) {
+      return result.data;
+    }
+    // in the case were http-client could not safely
+    // assume the response data is json (the content-type did
+    // not contain json) we will try to turn the stream
+    // into json
+    return result.json();
+  } catch(e) {
+    console.error('failed to get json', e);
+    throw e;
+  }
+}
+
 async function _webLoader(url) {
   if(!url.startsWith('http')) {
     throw new Error('NotFoundError');
   }
-  let result;
+  let data;
   try {
-    result = await httpClient.get(url, {agent});
+    const result = await httpClient.get(url, {agent});
+    data = await _getDocument(result);
   } catch(e) {
     throw new Error('NotFoundError');
   }
 
   return {
     contextUrl: null,
-    document: result.data,
+    document: data,
     documentUrl: url
   };
 }


### PR DESCRIPTION
This fixes an error I found while testing the new vc-status-list with the `vdl-test-suite`.

The context type returned from `https://w3id.org/vdl/v1` is `application/octet-stream`.

Because `@digitalbazaar/http-client` only parses response data if it contains a `context-type` that contains json:

https://github.com/digitalbazaar/http-client/blob/ad88815723bb5e1821036754345297d71e26db5a/main.js#L64-L71

This results in the context being null in the documentLoader. 
Which brings me to why this is a draft PR.

This fix assumes that if a url is passed to `documentLoader` and we're allowing 
loading documents from the web then we expect that url to return a document regardless of `content-type`.